### PR TITLE
Fix missing FontAwesome special characters

### DIFF
--- a/views/public/css/avantsearch.css
+++ b/views/public/css/avantsearch.css
@@ -496,7 +496,8 @@ a.search-reset-link:hover {
 
 .search-selector-button:after {
 	content: "\f0d7";
-	font-family: "FontAwesome";
+	font-family: "Font Awesome 5 Free";
+	font-weight: bold;
 	padding-left: 6px;
 	float: right;
 }
@@ -666,12 +667,13 @@ a.search-reset-link:hover {
 .search-pagination-next a:after {
 	content: "\f105";
 	text-indent: 0;
+	font-weight: bold;
 }
 
 .search-pagination-next a:after,
 .search-pagination-previous a:after {
 	color: var(--link-color);
-	font-family: "FontAwesome";
+	font-family: "Font Awesome 5 Free";
 	height: 24px;
 	left: 0;
 	position: absolute;


### PR DESCRIPTION
Fixes #6

The current implementation does not load the arrow icons correctly, as you can see here:
![Screenshot 2024-06-20 141354](https://github.com/gsoules/AvantSearch/assets/43964592/15ab8571-ccaa-4227-8e32-659b942c4f42)

According to [these](https://stackoverflow.com/a/20782415) instructions, the CSS styling must be corrected. With those corrections the icons are shown again:
![Screenshot 2024-06-20 141644](https://github.com/gsoules/AvantSearch/assets/43964592/d0ff1e1c-014b-4635-a425-f7575a8071d3)

There is another occurrence wich calls `"FontAwesome"`: https://github.com/gsoules/AvantSearch/blob/e767b9044a14d6737a3bf55ee7f5a554521a8ef7/views/public/css/avantsearch.css#L497-L500
Which I left because I didn't know what it affected. But I can deliver that later if wanted.