### PR TITLE
Add an optional searchbar at the results page

### DIFF
--- a/config_form.php
+++ b/config_form.php
@@ -134,7 +134,12 @@ if (AvantSearch::usePdfSearch())
     </div>
 </div>
 
-
-
-
-
+<div class="field">
+    <div class="two columns alpha">
+        <label><?php echo CONFIG_LABEL_SEARCHBAR_ON_RESULTS; ?></label>
+    </div>
+    <div class="inputs five columns omega">
+        <p class="explanation"><?php echo __('Adds an additional searchbar at the results page'); ?></p>
+        <?php echo $view->formCheckbox(SearchConfig::OPTION_SEARCHBAR_ON_RESULTS, true, array('checked' => (boolean)get_option(SearchConfig::OPTION_SEARCHBAR_ON_RESULTS))); ?>
+    </div>
+</div>

--- a/models/SearchConfig.php
+++ b/models/SearchConfig.php
@@ -9,6 +9,7 @@ define('CONFIG_LABEL_LAYOUTS', __('Layouts'));
 define('CONFIG_LABEL_PDFSEARCH', __('PDF Search'));
 define('CONFIG_LABEL_RELATIONSHIPS_VIEW', __('Relationships View'));
 define('CONFIG_LABEL_TITLES_ONLY',  __('Titles Only'));
+define('CONFIG_LABEL_SEARCHBAR_ON_RESULTS',  __('Searchbar on results'));
 
 class SearchConfig extends ConfigOptions
 {
@@ -21,6 +22,7 @@ class SearchConfig extends ConfigOptions
     const OPTION_PDFSEARCH = 'avantsearch_pdfsearch';
     const OPTION_RELATIONSHIPS_VIEW = 'avantsearch_relationships_view';
     const OPTION_TITLES_ONLY = 'avantsearch_titles_only';
+    const OPTION_SEARCHBAR_ON_RESULTS = 'avantsearch_searchbar_on_results';
 
     public static function emitInnoDbMessage($engine)
     {
@@ -303,6 +305,7 @@ class SearchConfig extends ConfigOptions
         self::saveOptionDataForIntegerSorting();
 
         set_option(self::OPTION_TITLES_ONLY, intval($_POST[self::OPTION_TITLES_ONLY]));
+        set_option(self::OPTION_SEARCHBAR_ON_RESULTS, intval($_POST[self::OPTION_SEARCHBAR_ON_RESULTS]));
         set_option(self::OPTION_RELATIONSHIPS_VIEW, intval($_POST[self::OPTION_RELATIONSHIPS_VIEW]));
         set_option(self::OPTION_ADDRESS_SORTING, intval($_POST[self::OPTION_ADDRESS_SORTING]));
         set_option(self::OPTION_ELASTICSEARCH, $elasticsearchOption);

--- a/views/public/simple-searchbar.php
+++ b/views/public/simple-searchbar.php
@@ -1,0 +1,43 @@
+<!-- Simple searchbar  -->
+
+<search id=simple-search>
+    <form id="search-form" class="advanced-search-form" action="find" aria-label="Search">
+        <input id="query" class="advanced-search-form input" name="keywords" type="search" placeholder="Search Items" value="<?php echo $_REQUEST["keywords"] ?>">
+        <input type="hidden" name="tags" value="<?php echo $_REQUEST["tags"] ?>">
+        <input type="hidden" name="year_start" value="<?php echo $_REQUEST["year_start"] ?>">
+        <input type="hidden" name="year_end" value="<?php echo $_REQUEST["year_end"] ?>">
+        <button id="submit_search" class="advanced-search-form button" type="submit"></button>
+        <a href="find/advanced" id="advanced-search-link">→ Advanced Search</a>
+    </form>
+</search>
+
+<style>
+    #simple-search {
+        margin-top: 3rem;
+        margin-bottom: 3rem;
+    }
+
+    #simple-search input[type="search"]#query {
+        margin-bottom: 0px;
+    }
+
+     #search-form {
+        box-shadow: none;
+    }
+
+    #submit_search {
+        padding-right: 10px;
+        margin-left: 10px;
+        margin-bottom: 0px;
+    }
+
+    #advanced-search-link {
+        margin-left: 20px;
+        margin-right: 20px;
+        margin-bottom: 0px;
+        white-space: nowrap;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+    }
+</style>

--- a/views/public/simple-searchbar.php
+++ b/views/public/simple-searchbar.php
@@ -1,11 +1,11 @@
 <!-- Simple searchbar  -->
 
-<search id=simple-search>
+<search id="simple-search">
     <form id="search-form" class="advanced-search-form" action="find" aria-label="Search">
-        <input id="query" class="advanced-search-form input" name="keywords" type="search" placeholder="Search Items" value="<?php echo $_REQUEST["keywords"] ?>">
-        <input type="hidden" name="tags" value="<?php echo $_REQUEST["tags"] ?>">
-        <input type="hidden" name="year_start" value="<?php echo $_REQUEST["year_start"] ?>">
-        <input type="hidden" name="year_end" value="<?php echo $_REQUEST["year_end"] ?>">
+        <input id="query" class="advanced-search-form input" name="keywords" type="search" placeholder="Search Items" value="<?php echo htmlspecialchars($_REQUEST["keywords"], ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="hidden" name="tags" value="<?php echo htmlspecialchars($_REQUEST["tags"], ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="hidden" name="year_start" value="<?php echo htmlspecialchars($_REQUEST["year_start"], ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="hidden" name="year_end" value="<?php echo htmlspecialchars($_REQUEST["year_end"], ENT_QUOTES, 'UTF-8'); ?>">
         <button id="submit_search" class="advanced-search-form button" type="submit"></button>
         <a href="find/advanced" id="advanced-search-link">→ Advanced Search</a>
     </form>

--- a/views/public/table-view.php
+++ b/views/public/table-view.php
@@ -57,6 +57,9 @@ $optionSelectorsHtml .= $searchResults->emitSelectorForFilter();
 echo head(array('title' => $resultsMessage));
 echo "<div id='{$searchResults->getSearchResultsContainerName()}'>";
 
+include 'simple-searchbar.php';
+// echo $this->partial('simple-searchbar.php', array('query' => $_REQUEST["keywords"]));
+
 $paginationLinks = pagination_links();
 echo "<div id='search-results-title'><span>$resultsMessage</span>$paginationLinks</div>";
 

--- a/views/public/table-view.php
+++ b/views/public/table-view.php
@@ -57,8 +57,11 @@ $optionSelectorsHtml .= $searchResults->emitSelectorForFilter();
 echo head(array('title' => $resultsMessage));
 echo "<div id='{$searchResults->getSearchResultsContainerName()}'>";
 
-include 'simple-searchbar.php';
-// echo $this->partial('simple-searchbar.php', array('query' => $_REQUEST["keywords"]));
+if(get_option(SearchConfig::OPTION_SEARCHBAR_ON_RESULTS))
+{
+    include 'simple-searchbar.php';
+    // echo $this->partial('simple-searchbar.php', array('query' => $_REQUEST["keywords"]));
+}
 
 $paginationLinks = pagination_links();
 echo "<div id='search-results-title'><span>$resultsMessage</span>$paginationLinks</div>";


### PR DESCRIPTION
Adds an query preserving searchbar at the results page:

![image](https://github.com/user-attachments/assets/b05bf348-da72-4e63-a10b-5e5a83fb382c)

You can test it (on a more customized AvantSearch version) at https://fdz.bib.uni-mannheim.de/nikephoros/find if you like.

I might need to remove more or all styling from [simple-searchbar.php](https://github.com/gsoules/AvantSearch/compare/master...csidirop:feature/searchbar?expand=1#diff-c16d3e38eab92fd713e5265763a0bfa8c4a86d98507f144144f045adf8aa8964) to be more compatible with other themes. 

